### PR TITLE
set-aws-region

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
   <version>1.0-SNAPSHOT</version>
   <description>Dropwizard bundle to signal the AutoScalingGroup via CloudFormation SignalResource API when running on an AWS EC2 instance.</description>
 
+  <properties>
+    <aws-java-sdk.version>1.10.9</aws-java-sdk.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.dropwizard</groupId>
@@ -26,6 +30,11 @@
       <version>${aws-java-sdk.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-autoscaling</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
@@ -38,8 +47,16 @@
     </dependency>
   </dependencies>
 
-  <properties>
-    <aws-java-sdk.version>1.9.35</aws-java-sdk.version>
-  </properties>
-
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/test/java/net/eldeen/dropwizard/CfSignalResourceBundleTest.java
+++ b/src/test/java/net/eldeen/dropwizard/CfSignalResourceBundleTest.java
@@ -29,7 +29,7 @@ public class CfSignalResourceBundleTest {
     final LifecycleEnvironment lifecycleEnvironment = mock(LifecycleEnvironment.class);
     when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
 
-    new CfSignalResourceBundle("autoScalingGroup", "stackName").run(environment);
+    new CfSignalResourceBundle("autoScalingGroup", "stackName", "us-west-2").run(environment);
 
     verifyZeroInteractions(lifecycleEnvironment);
   }
@@ -41,7 +41,7 @@ public class CfSignalResourceBundleTest {
     final LifecycleEnvironment lifecycleEnvironment = mock(LifecycleEnvironment.class);
     when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
 
-    new CfSignalResourceBundle("autoScalingGroup", "stackName").run(environment);
+    new CfSignalResourceBundle("autoScalingGroup", "stackName", "us-west-2").run(environment);
 
     verify(lifecycleEnvironment).addServerLifecycleListener(any(ServerLifecycleListener.class));
   }


### PR DESCRIPTION
Require the aws region to be provided as an argument and use it to configure the client
Rename logicalResourceId to awsResourceName to make it more obvious
Incorporate the pom changes that were on the lookupASG branch
